### PR TITLE
Add missing animations from v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,31 @@ All the animations are organized by their group. Many of them have additional pa
 - `flash`
 - `pulse`
 - `rubberBand`
-- `shake`
+- `shakeX`
+- `shakeY`
+- `headShake`
 - `swing`
 - `tada`
 - `wobble`
 - `jello`
+- `heartBeat`
+
+### Back
+
+- `backInDown`
+- `backInLeft`
+- `backInRight`
+- `backInUp`
+
+- `backOutDown`
+- `backOutLeft`
+- `backOutRight`
+- `backOutUp`
 
 ### Bouncing
 
 - `bounceIn`
-- `bouceOut`. Additional param: `scale`
+- `bounceOut`. Additional param: `scale`
 
 The following bouncing animations have additional params `a, b, c, d` for `translate`
 
@@ -100,6 +115,7 @@ The following bouncing animations have additional params `a, b, c, d` for `trans
 - `bounceInLeft`
 - `bounceInRight`
 - `bounceInUp`
+
 - `bounceOutDown`
 - `bounceOutLeft`
 - `bounceOutRight`
@@ -107,18 +123,42 @@ The following bouncing animations have additional params `a, b, c, d` for `trans
 
 ### Fading
 
-All fading animations have additional params `fromOpacity, toOpacity` for `opacity` transition and `a, b` for `translate`.
+All fading animations have additional params `fromOpacity`, `toOpacity` for `opacity` transition and `a, b` for `translate`.
 
 - `fadeIn`
 - `fadeInDown`
 - `fadeInLeft`
 - `fadeInRight`
 - `fadeInUp`
+
+- `fadeInDownBig`
+- `fadeInLeftBig`
+- `fadeInRightBig`
+- `fadeInUpBig`
+
 - `fadeOut`
 - `fadeOutDown`
 - `fadeOutLeft`
 - `fadeOutRight`
 - `fadeOutUp`
+
+- `fadeOutDownBig`
+- `fadeOutLeftBig`
+- `fadeOutRightBig`
+- `fadeOutUpBig`
+
+The following fading animations do not have `a, b` for `translate` but `fromX`,`fromY`,`toX`,`toY` instead.
+
+- `fadeInTopLeft`
+- `fadeInTopRight`
+- `fadeInBottomLeft`
+- `fadeInBottomRight`
+
+- `fadeOutTopLeft`
+- `fadeOutTopRight`
+- `fadeOutBottomLeft`
+- `fadeOutBottomRight`
+
 
 ### Sliding
 
@@ -144,11 +184,15 @@ Sliding animations are basically fading animations without a change of `opacity`
 ### LightSpeed
 
 - `lightSpeedIn`
+- `lightSpeedLeft`
+- `lightSpeedIn`
 - `lightSpeedOut`
+- `lightSpeedOutRight` (same as `lightSpeedOut`)
+- `lightSpeedOutLeft`
 
 ### Rotating
 
-All rotating animations have additional params `fromOpacity, toOpacity` for `opacity` transition, `origin` for `transform-origin` and `degrees` for `rotate3d`.
+All rotating animations have additional params `fromOpacity`, `toOpacity` for `opacity` transition, `origin` for `transform-origin` and `degrees` for `rotate3d`.
 
 - `rotateIn`
 - `rotateInDownLeft`
@@ -179,6 +223,7 @@ The following zooming animations have additional params `a, b` for `translate`
 - `zoomInLeft`
 - `zoomInRight`
 - `zoomInUp`
+
 - `zoomOutDown`
 - `zoomOutLeft`
 - `zoomOutRight`
@@ -186,7 +231,7 @@ The following zooming animations have additional params `a, b` for `translate`
 
 ## Advanced params
 
-Many of the animations support also other params like `scale`, `fromOpacity`, `toOpacity` and much more, allowing extremely flexible usage and customisation if you're not happy with default values. 
+Many of the animations support also other params like `scale`, `fromOpacity`, `toOpacity` and much more, allowing extremely flexible usage and customization if you're not happy with default values. 
 
 Single letters like `a, b, c, d` are used for the steps of some animations: `a` is the starting value, `d` is the ending.  
 The animated property they refer to depends on the animation and the direction: usually `translate` on axis Y from `-Down/-Up`, axis X for `-Left/-Right`.

--- a/projects/ng-animate/src/lib/attention-seekers.ts
+++ b/projects/ng-animate/src/lib/attention-seekers.ts
@@ -1,9 +1,9 @@
 import {
-  AnimationReferenceMetadata,
   animation,
   style,
   animate,
   keyframes,
+  useAnimation,
 } from '@angular/animations';
 import { DEFAULT_TIMING } from './utils';
 
@@ -72,20 +72,32 @@ export const shake = animation(
     '{{ timing }}s {{ delay }}s',
     keyframes([
       style({ transform: 'translate3d(0, 0, 0)', offset: 0 }),
-      style({ transform: 'translate3d(-10px, 0, 0)', offset: 0.1 }),
-      style({ transform: 'translate3d(10px, 0, 0)', offset: 0.2 }),
-      style({ transform: 'translate3d(-10px, 0, 0)', offset: 0.3 }),
-      style({ transform: 'translate3d(10px, 0, 0)', offset: 0.4 }),
-      style({ transform: 'translate3d(-10px, 0, 0)', offset: 0.5 }),
-      style({ transform: 'translate3d(10px, 0, 0)', offset: 0.6 }),
-      style({ transform: 'translate3d(-10px, 0, 0)', offset: 0.7 }),
-      style({ transform: 'translate3d(10px, 0, 0)', offset: 0.8 }),
-      style({ transform: 'translate3d(-10px, 0, 0)', offset: 0.9 }),
+      style({ transform: 'translate3d({{ translateB }})', offset: 0.1 }),
+      style({ transform: 'translate3d({{ translateA }})', offset: 0.2 }),
+      style({ transform: 'translate3d({{ translateB }})', offset: 0.3 }),
+      style({ transform: 'translate3d({{ translateA }})', offset: 0.4 }),
+      style({ transform: 'translate3d({{ translateB }})', offset: 0.5 }),
+      style({ transform: 'translate3d({{ translateA }})', offset: 0.6 }),
+      style({ transform: 'translate3d({{ translateB }})', offset: 0.7 }),
+      style({ transform: 'translate3d({{ translateA }})', offset: 0.8 }),
+      style({ transform: 'translate3d({{ translateB }})', offset: 0.9 }),
       style({ transform: 'translate3d(0, 0, 0)', offset: 1 }),
     ])
   ),
-  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+  {
+    params: {
+      timing: DEFAULT_TIMING,
+      delay: 0,
+      translateA: '-10px, 0, 0',
+      translateB: '10px, 0, 0',
+    },
+  }
 );
+
+export const shakeX = shake;
+export const shakeY = useAnimation(shake, {
+  params: { translateA: '0, -10px, 0', translateB: '0, 10px, 0' },
+});
 
 export const swing = animation(
   animate(
@@ -202,6 +214,41 @@ export const jello = animation(
         offset: 0.88,
       }),
       style({ transform: 'none', offset: 1 }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const heartBeat = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s ease-in-out',
+    keyframes([
+      style({ transform: 'scale(1)', offset: 0 }),
+      style({ transform: 'scale({{ scale }})', offset: 0.14 }),
+      style({ transform: 'scale(1)', offset: 0.28 }),
+      style({
+        transform: 'scale({{ scale }})',
+        offset: 0.42,
+      }),
+      style({
+        transform: 'scale(1)',
+        offset: 0.7,
+      }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING * 1.3, scale: 1.3, delay: 0 } }
+);
+
+export const headShake = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s ease-in-out',
+    keyframes([
+      style({ transform: 'translateX(0)', offset: 0 }),
+      style({ transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065 }),
+      style({ transform: 'translateX(5px) rotateY(7deg)', offset: 0.185 }),
+      style({ transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315 }),
+      style({ transform: 'translateX(2px) rotateY(3deg)', offset: 0.435 }),
+      style({ transform: 'translateX(0)', offset: 0.5 }),
     ])
   ),
   { params: { timing: DEFAULT_TIMING, delay: 0 } }

--- a/projects/ng-animate/src/lib/back.ts
+++ b/projects/ng-animate/src/lib/back.ts
@@ -1,0 +1,134 @@
+import { animate, animation, keyframes, style } from '@angular/animations';
+import { DEFAULT_TIMING } from './utils';
+
+// https://github.com/animate-css/animate.css/tree/main/source/back_entrances
+
+export const backInUp = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({
+        opacity: 0.7,
+        transform: 'translateY(1200px) scale(0.7)',
+        offset: 0,
+      }),
+      style({
+        opacity: 0.7,
+        transform: 'translateY(0px) scale(0.7)',
+        offset: 0.8,
+      }),
+      style({ opacity: 1, transform: 'scale(1)', offset: 1 }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const backInDown = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({
+        opacity: 0.7,
+        transform: 'translateY(-1200px) scale(0.7)',
+        offset: 0,
+      }),
+      style({
+        opacity: 0.7,
+        transform: 'translateY(0px) scale(0.7)',
+        offset: 0.8,
+      }),
+      style({ opacity: 1, transform: 'scale(1)', offset: 1 }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const backInLeft = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({
+        opacity: 0.7,
+        transform: 'translateX(-2000px) scale(0.7)',
+        offset: 0,
+      }),
+      style({
+        opacity: 0.7,
+        transform: 'translateX(0px) scale(0.7)',
+        offset: 0.8,
+      }),
+      style({ opacity: 1, transform: 'scale(1)', offset: 1 }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const backInRight = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({
+        opacity: 0.7,
+        transform: 'translateX(2000px) scale(0.7)',
+        offset: 0,
+      }),
+      style({
+        opacity: 0.7,
+        transform: 'translateX(0px) scale(0.7)',
+        offset: 0.8,
+      }),
+      style({ opacity: 1, transform: 'scale(1)', offset: 1 }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+// https://github.com/animate-css/animate.css/tree/main/source/back_exits
+
+export const backOutUp = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({ opacity: 1.0, transform: 'scale(1)' }),
+      style({ opacity: 0.7, transform: 'translateY(0px) scale(0.7)' }),
+      style({ opacity: 0.7, transform: 'translateY(-700px) scale(0.7)' }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const backOutDown = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({ opacity: 1.0, transform: 'scale(1)' }),
+      style({ opacity: 0.7, transform: 'translateY(0px) scale(0.7)' }),
+      style({ opacity: 0.7, transform: 'translateY(700px) scale(0.7)' }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const backOutRight = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({ opacity: 1.0, transform: 'scale(1)' }),
+      style({ opacity: 0.7, transform: 'translateX(0px) scale(0.7)' }),
+      style({ opacity: 0.7, transform: 'translateX(2000px) scale(0.7)' }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);
+
+export const backOutLeft = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s',
+    keyframes([
+      style({ opacity: 1.0, transform: 'scale(1)' }),
+      style({ opacity: 0.7, transform: 'translateX(0px) scale(0.7)' }),
+      style({ opacity: 0.7, transform: 'translateX(-2000px) scale(0.7)' }),
+    ])
+  ),
+  { params: { timing: DEFAULT_TIMING, delay: 0 } }
+);

--- a/projects/ng-animate/src/lib/bouncing.ts
+++ b/projects/ng-animate/src/lib/bouncing.ts
@@ -1,9 +1,9 @@
 import {
-  AnimationReferenceMetadata,
   animation,
   style,
   animate,
-  keyframes
+  keyframes,
+  AnimationReferenceMetadata,
 } from '@angular/animations';
 import { DEFAULT_TIMING } from './utils';
 
@@ -17,16 +17,21 @@ export const bounceIn = animation(
       style({
         opacity: 1,
         transform: 'scale3d(1.03, 1.03, 1.03)',
-        offset: 0.6
+        offset: 0.6,
       }),
       style({ transform: 'scale3d(.97, .97, .97)', offset: 0.8 }),
-      style({ opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1 })
+      style({ opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1 }),
     ])
   ),
   { params: { timing: DEFAULT_TIMING, delay: 0 } }
 );
 
-export function bounceInY(a, b, c, d) {
+export function bounceInY(
+  a: string,
+  b: string,
+  c: string,
+  d: string
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s cubic-bezier(0.215, 0.610, 0.355, 1.000)',
@@ -34,16 +39,16 @@ export function bounceInY(a, b, c, d) {
         style({
           opacity: 0,
           transform: 'translate3d(0, {{ a }}, 0)',
-          offset: 0
+          offset: 0,
         }),
         style({
           opacity: 1,
           transform: 'translate3d(0, {{ b }}, 0)',
-          offset: 0.6
+          offset: 0.6,
         }),
         style({ transform: 'translate3d(0, {{ c }}, 0)', offset: 0.75 }),
         style({ transform: 'translate3d(0, {{ d }}, 0)', offset: 0.9 }),
-        style({ opacity: 1, transform: 'none', offset: 1 })
+        style({ opacity: 1, transform: 'none', offset: 1 }),
       ])
     ),
     {
@@ -53,13 +58,18 @@ export function bounceInY(a, b, c, d) {
         a,
         b,
         c,
-        d
-      }
+        d,
+      },
     }
   );
 }
 
-export function bounceInX(a, b, c, d) {
+export function bounceInX(
+  a: string,
+  b: string,
+  c: string,
+  d: string
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s cubic-bezier(0.215, 0.610, 0.355, 1.000)',
@@ -67,16 +77,16 @@ export function bounceInX(a, b, c, d) {
         style({
           opacity: 0,
           transform: 'translate3d({{ a }}, 0, 0)',
-          offset: 0
+          offset: 0,
         }),
         style({
           opacity: 1,
           transform: 'translate3d({{ b }}, 0, 0)',
-          offset: 0.6
+          offset: 0.6,
         }),
         style({ transform: 'translate3d({{ c }}, 0, 0)', offset: 0.75 }),
         style({ transform: 'translate3d({{ d }}, 0, 0)', offset: 0.9 }),
-        style({ opacity: 1, transform: 'none', offset: 1 })
+        style({ opacity: 1, transform: 'none', offset: 1 }),
       ])
     ),
     {
@@ -86,8 +96,8 @@ export function bounceInX(a, b, c, d) {
         a,
         b,
         c,
-        d
-      }
+        d,
+      },
     }
   );
 }
@@ -108,20 +118,25 @@ export const bounceOut = animation(
       style({
         opacity: 1,
         transform: 'scale3d({{ scale }}, {{ scale }}, {{ scale }})',
-        offset: 0.5
+        offset: 0.5,
       }),
       style({
         opacity: 1,
         transform: 'scale3d({{ scale }}, {{ scale }}, {{ scale }})',
-        offset: 0.55
+        offset: 0.55,
       }),
-      style({ opacity: 0, transform: 'scale3d(.3, .3, .3)', offset: 1 })
+      style({ opacity: 0, transform: 'scale3d(.3, .3, .3)', offset: 1 }),
     ])
   ),
   { params: { timing: DEFAULT_TIMING, delay: 0, scale: 1.1 } }
 );
 
-export function bounceOutY(a, b, c, d) {
+export function bounceOutY(
+  a: string,
+  b: string,
+  c: string,
+  d: string
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
@@ -130,18 +145,18 @@ export function bounceOutY(a, b, c, d) {
         style({
           opacity: 1,
           transform: 'translate3d(0, {{ b }}, 0)',
-          offset: 0.4
+          offset: 0.4,
         }),
         style({
           opacity: 1,
           transform: 'translate3d(0, {{ c }}, 0)',
-          offset: 0.45
+          offset: 0.45,
         }),
         style({
           opacity: 0,
           transform: 'translate3d(0, {{ d }}, 0)',
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     {
@@ -151,13 +166,13 @@ export function bounceOutY(a, b, c, d) {
         a,
         b,
         c,
-        d
-      }
+        d,
+      },
     }
   );
 }
 
-export function bounceOutX(a, b) {
+export function bounceOutX(a: string, b: string): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
@@ -165,13 +180,13 @@ export function bounceOutX(a, b) {
         style({
           opacity: 1,
           transform: 'translate3d({{ a }}, 0, 0)',
-          offset: 0.2
+          offset: 0.2,
         }),
         style({
           opacity: 0,
           transform: 'translate3d({{ b }}, 0, 0)',
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }

--- a/projects/ng-animate/src/lib/fading.ts
+++ b/projects/ng-animate/src/lib/fading.ts
@@ -1,140 +1,198 @@
-import {
-  AnimationReferenceMetadata,
-  animation,
-  style,
-  animate,
-  keyframes
-} from '@angular/animations';
+import { animate, animation, AnimationReferenceMetadata, keyframes, style } from '@angular/animations';
+
 import { DEFAULT_TIMING } from './utils';
 
-export function fadeInX(a, b) {
+export function fadeXY(
+  fromX: string | 0,
+  fromY: string | 0,
+  toX: string | 0,
+  toY: string | 0,
+  fromOpacity = 0,
+  toOpacity = 1
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
       keyframes([
         style({
-          opacity: 0,
-          transform: 'translate3d({{ a }}, 0, 0)',
-          offset: 0
+          opacity: '{{ fromOpacity }}',
+          transform: 'translate3d({{ fromX }}, {{ fromY }}, 0)',
+          offset: 0,
         }),
         style({
-          opacity: 1,
-          transform: 'translate3d({{ b }}, 0, 0)',
-          offset: 1
-        })
+          opacity: '{{ toOpacity }}',
+          transform: 'translate3d({{ toX }}, {{ toY }}, 0)',
+          offset: 1,
+        }),
       ])
     ),
-    { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
+    {
+      params: {
+        timing: DEFAULT_TIMING,
+        delay: 0,
+        fromX,
+        toX,
+        fromY,
+        toY,
+        fromOpacity,
+        toOpacity,
+      },
+    }
   );
 }
 
-export function fadeInY(a, b) {
+export function fadeInX(
+  a: string | 0,
+  b: string | 0,
+  fromOpacity = 0,
+  toOpacity = 1
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
       keyframes([
         style({
-          opacity: 0,
-          transform: 'translate3d(0, {{ a }}, 0)',
-          offset: 0
+          opacity: '{{ fromOpacity }}',
+          transform: 'translate3d({{ a }}, 0, 0)',
+          offset: 0,
         }),
         style({
-          opacity: 1,
-          transform: 'translate3d(0, {{ b }}, 0)',
-          offset: 1
-        })
+          opacity: '{{ toOpacity }}',
+          transform: 'translate3d({{ b }}, 0, 0)',
+          offset: 1,
+        }),
       ])
     ),
-    { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
+    {
+      params: {
+        timing: DEFAULT_TIMING,
+        delay: 0,
+        a,
+        b,
+        fromOpacity,
+        toOpacity,
+      },
+    }
+  );
+}
+
+export function fadeInY(
+  a: string | 0,
+  b: string | 0,
+  fromOpacity = 0,
+  toOpacity = 1
+): AnimationReferenceMetadata {
+  return animation(
+    animate(
+      '{{ timing }}s {{ delay }}s',
+      keyframes([
+        style({
+          opacity: '{{ fromOpacity }}',
+          transform: 'translate3d(0, {{ a }}, 0)',
+          offset: 0,
+        }),
+        style({
+          opacity: '{{ toOpacity }}',
+          transform: 'translate3d(0, {{ b }}, 0)',
+          offset: 1,
+        }),
+      ])
+    ),
+    {
+      params: {
+        timing: DEFAULT_TIMING,
+        delay: 0,
+        a,
+        b,
+        fromOpacity,
+        toOpacity,
+      },
+    }
   );
 }
 
 export const fadeIn = fadeInX(0, 0);
 export const fadeInDown = fadeInY('-100%', 0);
+export const fadeInDownBig = fadeInY('-2000px', 0);
 export const fadeInUp = fadeInY('100%', 0);
+export const fadeInUpBig = fadeInY('2000px', 0);
 export const fadeInLeft = fadeInX('-100%', 0);
+export const fadeInLeftBig = fadeInX('-2000px', 0);
 export const fadeInRight = fadeInX('100%', 0);
+export const fadeInRightBig = fadeInX('2000px', 0);
 
-export function fadeOutX(a, b) {
-  return animation(
-    animate(
-      '{{ timing }}s {{ delay }}s',
-      keyframes([
-        style({
-          opacity: 1,
-          transform: 'translate3d({{ a }}, 0, 0)',
-          offset: 0
-        }),
-        style({
-          opacity: 0,
-          transform: 'translate3d({{ b }}, 0, 0)',
-          offset: 1
-        })
-      ])
-    ),
-    { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
-  );
+export const fadeInTopLeft = fadeXY('-100%', '-100%', 0, 0);
+export const fadeInTopRight = fadeXY('100%', '-100%', 0, 0);
+export const fadeInBottomLeft = fadeXY('-100%', '100%', 0, 0);
+export const fadeInBottomRight = fadeXY('100%', '100%', 0, 0);
+
+export function fadeOutX(
+  a: string | 0,
+  b: string | 0
+): AnimationReferenceMetadata {
+  return fadeInX(a, b, 1, 0);
 }
 
-export function fadeOutY(a, b) {
-  return animation(
-    animate(
-      '{{ timing }}s {{ delay }}s',
-      keyframes([
-        style({
-          opacity: 1,
-          transform: 'translate3d(0, {{ a }}, 0)',
-          offset: 0
-        }),
-        style({
-          opacity: 0,
-          transform: 'translate3d(0, {{ b }}, 0)',
-          offset: 1
-        })
-      ])
-    ),
-    { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
-  );
+export function fadeOutY(
+  a: string | 0,
+  b: string | 0
+): AnimationReferenceMetadata {
+  return fadeInY(a, b, 1, 0);
 }
 
 export const fadeOut = fadeOutX(0, 0);
 export const fadeOutDown = fadeOutY('-100%', 0);
+export const fadeOutDownBig = fadeOutY('-2000px', 0);
 export const fadeOutUp = fadeOutY('100%', 0);
+export const fadeOutUpBig = fadeOutY('2000px', 0);
 export const fadeOutLeft = fadeOutX('-100%', 0);
+export const fadeOutLeftBig = fadeOutX('-2000px', 0);
 export const fadeOutRight = fadeOutX('100%', 0);
+export const fadeOutRightBig = fadeOutX('2000px', 0);
 
-export function slideX(a, b) {
+export const fadeOutTopLeft = fadeXY('-100%', '-100%', 0, 0, 1, 0);
+export const fadeOutTopRight = fadeXY('100%', '-100%', 0, 0, 1, 0);
+export const fadeOutBottomLeft = fadeXY('-100%', '100%', 0, 0, 1, 0);
+export const fadeOutBottomRight = fadeXY('100%', '100%', 0, 0, 1, 0);
+
+export function slideX(
+  a: string | 0,
+  b: string | 0
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
       keyframes([
         style({
           transform: 'translate3d({{ a }}, 0, 0)',
-          offset: 0
+          offset: 0,
         }),
         style({
           transform: 'translate3d({{ b }}, 0, 0)',
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
   );
 }
 
-export function slideY(a, b) {
+export function slideY(
+  a: string | 0,
+  b: string | 0
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
       keyframes([
         style({
           transform: 'translate3d(0, {{ a }}, 0)',
-          offset: 0
+          offset: 0,
         }),
         style({
           transform: 'translate3d(0, {{ b }}, 0)',
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }

--- a/projects/ng-animate/src/lib/fading.ts
+++ b/projects/ng-animate/src/lib/fading.ts
@@ -141,19 +141,19 @@ export function fadeOutY(
 }
 
 export const fadeOut = fadeOutX(0, 0);
-export const fadeOutDown = fadeOutY('-100%', 0);
-export const fadeOutDownBig = fadeOutY('-2000px', 0);
-export const fadeOutUp = fadeOutY('100%', 0);
-export const fadeOutUpBig = fadeOutY('2000px', 0);
-export const fadeOutLeft = fadeOutX('-100%', 0);
-export const fadeOutLeftBig = fadeOutX('-2000px', 0);
-export const fadeOutRight = fadeOutX('100%', 0);
-export const fadeOutRightBig = fadeOutX('2000px', 0);
+export const fadeOutDown = fadeOutY(0, '100%');
+export const fadeOutDownBig = fadeOutY(0, '2000px');
+export const fadeOutUp = fadeOutY(0, '-100%');
+export const fadeOutUpBig = fadeOutY(0, '-2000px');
+export const fadeOutLeft = fadeOutX(0, '-100%');
+export const fadeOutLeftBig = fadeOutX(0, '-2000px');
+export const fadeOutRight = fadeOutX(0, '100%');
+export const fadeOutRightBig = fadeOutX(0, '2000px');
 
-export const fadeOutTopLeft = fadeXY('-100%', '-100%', 0, 0, 1, 0);
-export const fadeOutTopRight = fadeXY('100%', '-100%', 0, 0, 1, 0);
-export const fadeOutBottomLeft = fadeXY('-100%', '100%', 0, 0, 1, 0);
-export const fadeOutBottomRight = fadeXY('100%', '100%', 0, 0, 1, 0);
+export const fadeOutTopLeft = fadeXY(0, 0, '-100%', '-100%', 1, 0);
+export const fadeOutTopRight = fadeXY(0, 0, '100%', '-100%', 1, 0);
+export const fadeOutBottomLeft = fadeXY(0, 0, '-100%', '100%', 1, 0);
+export const fadeOutBottomRight = fadeXY(0, 0, '100%', '100%', 1, 0);
 
 export function slideX(
   a: string | 0,

--- a/projects/ng-animate/src/lib/flippers.ts
+++ b/projects/ng-animate/src/lib/flippers.ts
@@ -1,10 +1,5 @@
-import {
-  AnimationReferenceMetadata,
-  animation,
-  style,
-  animate,
-  keyframes
-} from '@angular/animations';
+import { animate, animation, AnimationReferenceMetadata, keyframes, style } from '@angular/animations';
+
 import { DEFAULT_TIMING } from './utils';
 
 export const flip = animation(
@@ -15,35 +10,38 @@ export const flip = animation(
       keyframes([
         style({
           transform: 'perspective(400px) rotate3d(0, 1, 0, -360deg)',
-          offset: 0
+          offset: 0,
         }),
         style({
           transform:
             'perspective(400px) scale3d(1.5, 1.5, 1.5) rotate3d(0, 1, 0, -190deg)',
-          offset: 0.4
+          offset: 0.4,
         }),
         style({
           transform:
             'perspective(400px) scale3d(1.5, 1.5, 1.5) rotate3d(0, 1, 0, -170deg)',
-          offset: 0.5
+          offset: 0.5,
         }),
         style({
           transform: 'perspective(400px) scale3d(.95, .95, .95)',
-          offset: 0.8
+          offset: 0.8,
         }),
         style({
           transform: 'perspective(400px)',
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
-    )
+    ),
   ],
   {
-    params: { timing: DEFAULT_TIMING, delay: 0 }
+    params: { timing: DEFAULT_TIMING, delay: 0 },
   }
 );
 
-export function flipIn(rotateX, rotateY) {
+export function flipIn(
+  rotateX: number,
+  rotateY: number
+): AnimationReferenceMetadata {
   return animation(
     [
       style({ 'backface-visibility': 'visible' }),
@@ -54,30 +52,30 @@ export function flipIn(rotateX, rotateY) {
             opacity: 0,
             transform:
               'perspective(400px) rotate3d({{ rotateX }}, {{ rotateY }}, 0, 90deg)',
-            offset: 0
+            offset: 0,
           }),
           style({
             opacity: 1,
             transform:
               'perspective(400px) rotate3d({{ rotateX }}, {{ rotateY }}, 0, -20deg)',
-            offset: 0.4
+            offset: 0.4,
           }),
           style({
             transform:
               'perspective(400px) rotate3d({{ rotateX }}, {{ rotateY }}, 0, 10deg)',
-            offset: 0.6
+            offset: 0.6,
           }),
           style({
             transform:
               'perspective(400px) rotate3d({{ rotateX }}, {{ rotateY }}, 0, -5deg)',
-            offset: 0.8
+            offset: 0.8,
           }),
           style({
             transform: 'perspective(400px) rotate3d(0, 0, 0, 0)',
-            offset: 1
-          })
+            offset: 1,
+          }),
         ])
-      )
+      ),
     ],
     { params: { timing: DEFAULT_TIMING, delay: 0, rotateX, rotateY } }
   );
@@ -86,7 +84,10 @@ export function flipIn(rotateX, rotateY) {
 export const flipInX = flipIn(1, 0);
 export const flipInY = flipIn(0, 1);
 
-export function flipOut(rotateX, rotateY) {
+export function flipOut(
+  rotateX: number,
+  rotateY: number
+): AnimationReferenceMetadata {
   return animation(
     [
       style({ 'backface-visibility': 'visible' }),
@@ -95,22 +96,22 @@ export function flipOut(rotateX, rotateY) {
         keyframes([
           style({
             transform: 'perspective(400px)',
-            offset: 0
+            offset: 0,
           }),
           style({
             opacity: 1,
             transform:
               'perspective(400px) rotate3d({{ rotateX }}, {{ rotateY }}, 0, -20deg)',
-            offset: 0.3
+            offset: 0.3,
           }),
           style({
             opacity: 0,
             transform:
               'perspective(400px) rotate3d({{ rotateX }}, {{ rotateY }}, 0, 90deg)',
-            offset: 1
-          })
+            offset: 1,
+          }),
         ])
-      )
+      ),
     ],
     { params: { timing: DEFAULT_TIMING, delay: 0, rotateX, rotateY } }
   );

--- a/projects/ng-animate/src/lib/lightspeed.ts
+++ b/projects/ng-animate/src/lib/lightspeed.ts
@@ -1,24 +1,27 @@
-import {
-  AnimationReferenceMetadata,
-  animation,
-  style,
-  animate,
-  keyframes,
-} from '@angular/animations';
+import { animate, animation, keyframes, style } from '@angular/animations';
+
 import { DEFAULT_TIMING } from './utils';
 
-export const lightSpeedIn = animation(
+export const lightSpeedInLeft = animation(
   animate(
-    '{{ timing }}s {{ delay }}s',
+    '{{ timing }}s {{ delay }}s ease-out',
     keyframes([
       style({
+        transform: 'translate3d(-100%, 0, 0) skewX(30deg)',
         opacity: 0,
-        transform: 'translate3d(100%, 0, 0) skewX(-30deg)',
         offset: 0,
       }),
       style({
+        transform: 'skewX(-20deg)',
         opacity: 1,
-        transform: 'translate3d(0, 0, 0) skewX(0)',
+        offset: 0.6,
+      }),
+      style({
+        transform: 'skewX(5deg)',
+        offset: 0.8,
+      }),
+      style({
+        transform: 'translate3d(0, 0, 0)',
         offset: 1,
       }),
     ])
@@ -28,9 +31,39 @@ export const lightSpeedIn = animation(
   }
 );
 
-export const lightSpeedOut = animation(
+export const lightSpeedIn = animation(
   animate(
     '{{ timing }}s {{ delay }}s ease-out',
+    keyframes([
+      style({
+        transform: 'translate3d(100%, 0, 0) skewX(-30deg)',
+        opacity: 0,
+        offset: 0,
+      }),
+      style({
+        transform: 'skewX(20deg)',
+        opacity: 1,
+        offset: 0.6,
+      }),
+      style({
+        transform: 'skewX(-5deg)',
+        offset: 0.8,
+      }),
+      style({
+        transform: 'translate3d(0, 0, 0)',
+        offset: 1,
+      }),
+    ])
+  ),
+  {
+    params: { timing: DEFAULT_TIMING, delay: 0 },
+  }
+);
+export const lightSpeedInRight = lightSpeedIn;
+
+export const lightSpeedOut = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s ease-in',
     keyframes([
       style({
         opacity: 1,
@@ -39,6 +72,28 @@ export const lightSpeedOut = animation(
       style({
         opacity: 0,
         transform: 'translate3d(100%, 0, 0) skewX(30deg)',
+        offset: 1,
+      }),
+    ])
+  ),
+  {
+    params: { timing: DEFAULT_TIMING, delay: 0 },
+  }
+);
+
+export const lightSpeedOutRight = lightSpeedOut;
+
+export const lightSpeedOutLeft = animation(
+  animate(
+    '{{ timing }}s {{ delay }}s ease-in',
+    keyframes([
+      style({
+        opacity: 1,
+        offset: 0,
+      }),
+      style({
+        opacity: 0,
+        transform: 'translate3d(-100%, 0, 0) skewX(-30deg)',
         offset: 1,
       }),
     ])

--- a/projects/ng-animate/src/lib/rotate.ts
+++ b/projects/ng-animate/src/lib/rotate.ts
@@ -1,33 +1,73 @@
-import {
-  AnimationReferenceMetadata,
-  animation,
-  style,
-  animate,
-  keyframes
-} from '@angular/animations';
+import { animate, animation, AnimationReferenceMetadata, keyframes, style } from '@angular/animations';
+
 import { DEFAULT_TIMING } from './utils';
 
-export function rotateInDirection(origin, degrees) {
+export function rotateInDirection(
+  origin: string,
+  degrees: string
+): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s',
       keyframes([
         style({
           'transform-origin': '{{ origin }}',
-          opacity: 0,
+          opacity: '{{ fromOpacity }}',
           transform: 'rotate3d(0, 0, 1, {{ degrees }})',
-          offset: 0
+          offset: 0,
         }),
         style({
           'transform-origin': '{{ origin }}',
-          opacity: 1,
+          opacity: '{{ toOpacity }}',
           transform: 'none',
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     {
-      params: { timing: DEFAULT_TIMING, delay: 0, origin, degrees }
+      params: {
+        timing: DEFAULT_TIMING,
+        delay: 0,
+        origin,
+        degrees,
+        fromOpacity: 0,
+        toOpacity: 1,
+      },
+    }
+  );
+}
+
+export function rotateOutDirection(
+  origin: string,
+  degrees: string
+): AnimationReferenceMetadata {
+  return animation(
+    animate(
+      '{{ timing }}s {{ delay }}s',
+      keyframes([
+        style({
+          'transform-origin': '{{ origin }}',
+          opacity: '{{ fromOpacity }}',
+          transform: 'none',
+          offset: 0,
+        }),
+        style({
+          'transform-origin': '{{ origin }}',
+          opacity: '{{ toOpacity }}',
+          transform: 'rotate3d(0, 0, 1, {{ degrees }})',
+          offset: 1,
+        }),
+      ])
+    ),
+    {
+      params: {
+        timing: DEFAULT_TIMING,
+        delay: 0,
+        origin,
+        degrees,
+        fromOpacity: 1,
+        toOpacity: 0,
+      },
     }
   );
 }
@@ -37,31 +77,6 @@ export const rotateInDownLeft = rotateInDirection('left bottom', '-45deg');
 export const rotateInDownRight = rotateInDirection('right bottom', '45deg');
 export const rotateInUpLeft = rotateInDirection('left bottom', '45deg');
 export const rotateInUpRight = rotateInDirection('right bottom', '-90deg');
-
-export function rotateOutDirection(origin, degrees) {
-  return animation(
-    animate(
-      '{{ timing }}s {{ delay }}s',
-      keyframes([
-        style({
-          'transform-origin': '{{ origin }}',
-          opacity: 1,
-          transform: 'none',
-          offset: 0
-        }),
-        style({
-          'transform-origin': '{{ origin }}',
-          opacity: 0,
-          transform: 'rotate3d(0, 0, 1, {{ degrees }})',
-          offset: 1
-        })
-      ])
-    ),
-    {
-      params: { timing: DEFAULT_TIMING, delay: 0, origin, degrees }
-    }
-  );
-}
 
 export const rotateOut = rotateOutDirection('center', '200deg');
 export const rotateOutDownLeft = rotateOutDirection('left bottom', '45deg');

--- a/projects/ng-animate/src/lib/specials.ts
+++ b/projects/ng-animate/src/lib/specials.ts
@@ -1,10 +1,5 @@
-import {
-  AnimationReferenceMetadata,
-  animation,
-  style,
-  animate,
-  keyframes,
-} from '@angular/animations';
+import { animate, animation, keyframes, style } from '@angular/animations';
+
 import { DEFAULT_TIMING } from './utils';
 
 export const hinge = animation(

--- a/projects/ng-animate/src/lib/zooming.ts
+++ b/projects/ng-animate/src/lib/zooming.ts
@@ -1,10 +1,5 @@
-import {
-  AnimationReferenceMetadata,
-  animation,
-  style,
-  animate,
-  keyframes
-} from '@angular/animations';
+import { animate, animation, AnimationReferenceMetadata, keyframes, style } from '@angular/animations';
+
 import { DEFAULT_TIMING } from './utils';
 
 export const zoomIn = animation(
@@ -15,22 +10,22 @@ export const zoomIn = animation(
         style({
           opacity: 0,
           transform: 'scale3d(.3, .3, .3)',
-          offset: 0
+          offset: 0,
         }),
         style({
           opacity: 1,
           transform: 'scale3d(1, 1, 1)',
-          offset: 0.5
-        })
+          offset: 0.5,
+        }),
       ])
-    )
+    ),
   ],
   {
-    params: { timing: DEFAULT_TIMING, delay: 0 }
+    params: { timing: DEFAULT_TIMING, delay: 0 },
   }
 );
 
-export function zoomInY(a, b) {
+export function zoomInY(a: string, b: string): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s cubic-bezier(0.550, 0.055, 0.675, 0.190)',
@@ -38,20 +33,20 @@ export function zoomInY(a, b) {
         style({
           opacity: 0,
           transform: `scale3d(.1, .1, .1) translate3d(0, {{ a }}, 0)`,
-          offset: 0
+          offset: 0,
         }),
         style({
           opacity: 1,
           transform: `scale3d(.475, .475, .475) translate3d(0, {{ b }}, 0)`,
-          offset: 0.6
-        })
+          offset: 0.6,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
   );
 }
 
-export function zoomInX(a, b) {
+export function zoomInX(a: string, b: string): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s cubic-bezier(0.550, 0.055, 0.675, 0.190)',
@@ -59,13 +54,13 @@ export function zoomInX(a, b) {
         style({
           opacity: 0,
           transform: `scale3d(.1, .1, .1) translate3d({{ a }}, 0, 0)`,
-          offset: 0
+          offset: 0,
         }),
         style({
           opacity: 1,
           transform: `scale3d(.475, .475, .475) translate3d({{ b }}, 0, 0)`,
-          offset: 0.6
-        })
+          offset: 0.6,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
@@ -84,26 +79,26 @@ export const zoomOut = animation(
       keyframes([
         style({
           opacity: 1,
-          offset: 0
+          offset: 0,
         }),
         style({
           opacity: 0,
           transform: 'scale3d(.3, .3, .3)',
-          offset: 0.5
+          offset: 0.5,
         }),
         style({
           opacity: 0,
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
-    )
+    ),
   ],
   {
-    params: { timing: DEFAULT_TIMING, delay: 0 }
+    params: { timing: DEFAULT_TIMING, delay: 0 },
   }
 );
 
-export function zoomOutY(a, b) {
+export function zoomOutY(a: string, b: string): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s cubic-bezier(0.550, 0.055, 0.675, 0.190)',
@@ -111,20 +106,20 @@ export function zoomOutY(a, b) {
         style({
           opacity: 1,
           transform: `scale3d(.475, .475, .475) translate3d(0, {{ a }}, 0)`,
-          offset: 0.4
+          offset: 0.4,
         }),
         style({
           opacity: 0,
           transform: `scale3d(.1, .1, .1) translate3d(0, {{ b }}, 0)`,
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }
   );
 }
 
-export function zoomOutX(a, b) {
+export function zoomOutX(a: string, b: string): AnimationReferenceMetadata {
   return animation(
     animate(
       '{{ timing }}s {{ delay }}s cubic-bezier(0.550, 0.055, 0.675, 0.190)',
@@ -132,13 +127,13 @@ export function zoomOutX(a, b) {
         style({
           opacity: 1,
           transform: `scale3d(.475, .475, .475) translate3d({{ a }}, 0, 0)`,
-          offset: 0.4
+          offset: 0.4,
         }),
         style({
           opacity: 0,
           transform: `scale3d(.1, .1, .1) translate3d({{ b }}, 0, 0)`,
-          offset: 1
-        })
+          offset: 1,
+        }),
       ])
     ),
     { params: { timing: DEFAULT_TIMING, delay: 0, a, b } }

--- a/projects/ng-animate/src/public-api.ts
+++ b/projects/ng-animate/src/public-api.ts
@@ -10,3 +10,4 @@ export * from './lib/lightspeed';
 export * from './lib/rotate';
 export * from './lib/specials';
 export * from './lib/zooming';
+export * from './lib/back';

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -23,7 +23,7 @@ small {
   display: flex;
   justify-content: center;
   min-height: 100vh;
-  width: 100vw;
+  width: 100%;
 }
 
 .content {

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -8,7 +8,7 @@ small {
   border: none;
   border-radius: 2px;
   color: #666;
-   cursor: pointer;
+  cursor: pointer;
   font-size: inherit;
   margin-top: 0.5rem;
   padding: 0.5rem 1rem;
@@ -31,15 +31,22 @@ small {
   text-align: center;
 }
 
-.box {
-  background-color: #fff;
-  border-radius: 3px;
-  height: 48px;
-  width: 48px;
-  margin: 0 auto;
-  margin-top: 5rem;
-}
-
 .animations {
   margin-top: 3rem;
+}
+
+input[type="number"] {
+  background-color: #fff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 2px;
+  margin: 0.5rem 0.1rem;
+}
+
+select {
+  background-color: #fff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 2px;
+  margin: 0.5rem 0.1rem;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,182 +1,70 @@
 <div class="container">
   <div class="content">
-    <h1>ng-animate</h1>
+    <h1 [@tada]="true">ng-animate</h1>
 
     <div class="animations">
-      <div
-        [@bounce]="bounce"
-        [@flash]="flash"
-        [@pulse]="pulse"
-        [@rubberBand]="rubberBand"
-        [@shake]="shake"
-        [@swing]="swing"
-        [@tada]="tada"
-        [@wobble]="wobble"
-        [@jello]="jello"
+      <h2>Available Animations</h2>
+      <app-example-box label="Attention Seekers" [animations]="attentionSeekersAnimations"></app-example-box>
+      <app-example-box label="Back entrances" [animations]="backEntrances"></app-example-box>
+      <app-example-box label="Back exits" [animations]="backExits"></app-example-box>
+      <app-example-box label="Bouncing entrances" [animations]="bouncingEntrances"></app-example-box>
+      <app-example-box label="Bouncing exits" [animations]="bouncingExits"></app-example-box>
+      <app-example-box label="Fading entrances" [animations]="fadingEntrances"></app-example-box>
+      <app-example-box label="Fading exits" [animations]="fadingExits"></app-example-box>
+      <app-example-box label="Flippers" [animations]="flippers"></app-example-box>
+      <app-example-box label="Lightspeed" [animations]="lightspeed"></app-example-box>
+      <app-example-box label="Rotating entrances" [animations]="rotatingEntrances"></app-example-box>
+      <app-example-box label="Rotating exits" [animations]="rotatingExits"></app-example-box>
 
-        class="box"
-      ></div>
-      <h2>Attention Seekers</h2>
-      <p>
-        <button
-          *ngFor="let animation of attentionSeekers"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
+      <app-example-box label="Specials" [animations]="specials"></app-example-box>
+      <app-example-box label="Zooming entrances" [animations]="zoomingEntrances"></app-example-box>
+      <app-example-box label="Zooming exits" [animations]="zoomingExits"></app-example-box>
 
-      <div
-        [@bounceIn]="bounceIn"
-        [@bounceInDown]="bounceInDown"
-        [@bounceInLeft]="bounceInLeft"
+      <app-example-box label="Sliding entrances" [animations]="slidingEntrances"></app-example-box>
+      <app-example-box label="Sliding exits" [animations]="slidingExits"></app-example-box>
+    </div>
+    <div class="animations">
+      <h2>Advanced Usage</h2>
+      <p>You can use parameters to modify the animations:</p>
 
-        [@bounceOut]="{ value: bounceOut, params: { scale: 1.25 } }"
-        [@bounceOutUp]="bounceOutUp"
-        [@bounceOutRight]="bounceOutRight"
+      <app-example-box label="Timing" [animations]="slidingExits" [params]="{ timing: animationTiming }">
+      </app-example-box>
+      <label>
+        Timing (in seconds): <input min="0" max="100" type="number" [(ngModel)]="animationTiming">
+      </label>
 
-        class="box"
-      ></div>
-      <h2>Bouncing <small>(not all directions are shown in the demo)</small></h2>
-      <p>
-        <button
-          *ngFor="let animation of bouncing"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@fadeIn]="{ value: fadeIn, params: { timing: 2 } }"
-        [@fadeInDown]="fadeInDown"
-        [@fadeInLeft]="fadeInLeft"
-        [@fadeOut]="fadeOut"
-        [@fadeOutUp]="fadeOutUp"
-        [@fadeOutRight]="fadeOutRight"
-
-        class="box"
-      ></div>
-      <h2>Fading <small>(not all directions are shown in the demo)</small></h2>
-      <p>
-        <button
-          *ngFor="let animation of fading"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@slideInDown]="slideInDown"
-        [@slideInLeft]="slideInLeft"
-        [@slideOutUp]="slideOutUp"
-        [@slideOutRight]="slideOutRight"
-
-        class="box"
-      ></div>
-      <h2>Sliding <small>(not all directions are shown in the demo)</small></h2>
-      <p>
-        <button
-          *ngFor="let animation of sliding"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@flip]="flip"
-        [@flipInX]="flipInX"
-        [@flipInY]="flipInY"
-        [@flipOutX]="flipOutX"
-        [@flipOutY]="flipOutY"
-
-        class="box"
-      ></div>
-      <h2>Flippers</h2>
-      <p>
-        <button
-          *ngFor="let animation of flippers"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@lightSpeedIn]="{ value: lightSpeedIn, params: { timing: 0.4 } }"
-        [@lightSpeedOut]="lightSpeedOut"
-
-        class="box"
-      ></div>
-      <h2>LightSpeed</h2>
-      <p>
-        <button
-          *ngFor="let animation of lightSpeed"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@rotateIn]="rotateIn"
-        [@rotateInDownLeft]="rotateInDownLeft"
-        [@rotateInUpRight]="rotateInUpRight"
-        [@rotateOut]="rotateOut"
-        [@rotateOutUpLeft]="rotateOutUpLeft"
-        [@rotateOutDownRight]="rotateOutDownRight"
-
-        class="box"
-      ></div>
-      <h2>Rotate <small>(not all directions are shown in the demo)</small></h2>
-      <p>
-        <button
-          *ngFor="let animation of rotate"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@hinge]="hinge"
-        [@jackInTheBox]="jackInTheBox"
-        [@rollIn]="rollIn"
-        [@rollOut]="rollOut"
-
-        class="box"
-      ></div>
-      <h2>Specials</h2>
-      <p>
-        <button
-          *ngFor="let animation of specials"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
-
-      <div
-        [@zoomIn]="zoomIn"
-        [@zoomInLeft]="zoomInLeft"
-        [@zoomInDown]="zoomInDown"
-        [@zoomOut]="zoomOut"
-        [@zoomOutUp]="zoomOutUp"
-        [@zoomOutRight]="zoomOutRight"
-
-        class="box"
-      ></div>
-      <h2>Zooming <small>(not all directions are shown in the demo)</small></h2>
-      <p>
-        <button
-          *ngFor="let animation of zooming"
-          (click)="animate(animation)"
-          class="btn"
-          type="button"
-        >{{ animation }}</button>
-      </p>
+      <app-example-box label="Multiple Params" [animations]="rotatingEntrances"
+        [params]="{
+        timing: animationTiming, fromOpacity: fromOpacity, toOpacity: toOpacity, degrees: degrees + 'deg', origin: originX + ' ' + originY }">
+      </app-example-box>
+      <label>
+        Timing: <input min="0" max="100" type="number" [(ngModel)]="animationTiming">
+      </label>
+      <br>
+      <label>
+        Degrees: <input min="-360" max="360" type="number" [(ngModel)]="degrees">
+      </label>
+      <br>
+      <label>
+        Origin:
+        <select [(ngModel)]="originX">
+          <option>top</option>
+          <option>center</option>
+          <option>bottom</option>
+        </select>
+        <select [(ngModel)]="originY">
+          <option>left</option>
+          <option>center</option>
+          <option>right</option>
+        </select>
+      </label>
+      <br>
+      <label>
+        Opacity from:
+        <input min="0" max="1" step="0.1" type="number" [(ngModel)]="fromOpacity">
+        to:
+        <input min="0" max="1" step="0.1" type="number" [(ngModel)]="toOpacity">
+      </label>
     </div>
   </div>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -33,7 +33,7 @@
         Timing (in seconds): <input min="0" max="100" type="number" [(ngModel)]="animationTiming">
       </label>
 
-      <app-example-box label="Multiple Params" [animations]="rotatingEntrances"
+      <app-example-box label="Multiple Params" [animations]="rotateInParams"
         [params]="{
         timing: animationTiming, fromOpacity: fromOpacity, toOpacity: toOpacity, degrees: degrees + 'deg', origin: originX + ' ' + originY }">
       </app-example-box>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,16 +1,16 @@
 import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
 import { AppComponent } from './app.component';
+import { ExampleBoxComponent } from './example-box/example-box.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ],
+      imports: [RouterTestingModule, NoopAnimationsModule, FormsModule],
+      declarations: [AppComponent, ExampleBoxComponent],
     }).compileComponents();
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -248,6 +248,8 @@ export class AppComponent {
     slideOutUp,
   };
 
+  rotateInParams = { rotateIn };
+
   // params
 
   animationTiming = 2;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,288 +1,259 @@
+import { transition, trigger, useAnimation } from '@angular/animations';
 import { Component, ViewEncapsulation } from '@angular/core';
-import { trigger, transition, useAnimation } from '@angular/animations';
-import {
-  bounce,
-  flash,
-  pulse,
-  rubberBand,
-  shake,
-  swing,
-  tada,
-  wobble,
-  jello,
-  bounceIn,
-  bounceInDown,
-  bounceInLeft,
-  bounceInRight,
-  bounceInUp,
-  bounceOut,
-  bounceOutDown,
-  bounceOutLeft,
-  bounceOutRight,
-  bounceOutUp,
-  fadeIn,
-  fadeInDown,
-  fadeInUp,
-  fadeInLeft,
-  fadeInRight,
-  fadeOut,
-  fadeOutDown,
-  fadeOutUp,
-  fadeOutLeft,
-  fadeOutRight,
-  slideInDown,
-  slideInUp,
-  slideInLeft,
-  slideInRight,
-  slideOutDown,
-  slideOutUp,
-  slideOutLeft,
-  slideOutRight,
-  flip,
-  flipInX,
-  flipInY,
-  flipOutX,
-  flipOutY,
-  lightSpeedIn,
-  lightSpeedOut,
-  rotateIn,
-  rotateInDownLeft,
-  rotateInDownRight,
-  rotateInUpLeft,
-  rotateInUpRight,
-  rotateOut,
-  rotateOutDownLeft,
-  rotateOutDownRight,
-  rotateOutUpLeft,
-  rotateOutUpRight,
-  hinge,
-  jackInTheBox,
-  rollIn,
-  rollOut,
-  zoomIn,
-  zoomInDown,
-  zoomInUp,
-  zoomInLeft,
-  zoomInRight,
-  zoomOut,
-  zoomOutDown,
-  zoomOutUp,
-  zoomOutLeft,
-  zoomOutRight
-} from 'ng-animate';
 
+import {
+    backInDown,
+    backInLeft,
+    backInRight,
+    backInUp,
+    backOutDown,
+    backOutLeft,
+    backOutRight,
+    backOutUp,
+    bounce,
+    bounceIn,
+    bounceInDown,
+    bounceInLeft,
+    bounceInRight,
+    bounceInUp,
+    bounceOut,
+    bounceOutDown,
+    bounceOutLeft,
+    bounceOutRight,
+    bounceOutUp,
+    fadeIn,
+    fadeInBottomLeft,
+    fadeInBottomRight,
+    fadeInDown,
+    fadeInDownBig,
+    fadeInLeft,
+    fadeInLeftBig,
+    fadeInRight,
+    fadeInRightBig,
+    fadeInTopLeft,
+    fadeInTopRight,
+    fadeInUp,
+    fadeInUpBig,
+    fadeOut,
+    fadeOutBottomLeft,
+    fadeOutBottomRight,
+    fadeOutDown,
+    fadeOutDownBig,
+    fadeOutLeft,
+    fadeOutLeftBig,
+    fadeOutRight,
+    fadeOutRightBig,
+    fadeOutTopLeft,
+    fadeOutTopRight,
+    fadeOutUp,
+    fadeOutUpBig,
+    flash,
+    flip,
+    flipInX,
+    flipInY,
+    flipOutX,
+    flipOutY,
+    headShake,
+    heartBeat,
+    hinge,
+    jackInTheBox,
+    jello,
+    lightSpeedInLeft,
+    lightSpeedInRight,
+    lightSpeedOutLeft,
+    lightSpeedOutRight,
+    pulse,
+    rollIn,
+    rollOut,
+    rotateIn,
+    rotateInDownLeft,
+    rotateInDownRight,
+    rotateInUpLeft,
+    rotateInUpRight,
+    rotateOut,
+    rotateOutDownLeft,
+    rotateOutDownRight,
+    rotateOutUpLeft,
+    rotateOutUpRight,
+    rubberBand,
+    shakeX,
+    shakeY,
+    slideInDown,
+    slideInLeft,
+    slideInRight,
+    slideInUp,
+    slideOutDown,
+    slideOutLeft,
+    slideOutRight,
+    slideOutUp,
+    swing,
+    tada,
+    wobble,
+    zoomIn,
+    zoomInDown,
+    zoomInLeft,
+    zoomInRight,
+    zoomInUp,
+    zoomOut,
+    zoomOutDown,
+    zoomOutLeft,
+    zoomOutRight,
+    zoomOutUp
+} from 'ng-animate';
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['./app.component.css'],
   encapsulation: ViewEncapsulation.None,
-  animations: [
-    trigger('bounce', [transition('* => *', useAnimation(bounce))]),
-    trigger('flash', [transition('* => *', useAnimation(flash))]),
-    trigger('pulse', [transition('* => *', useAnimation(pulse))]),
-    trigger('rubberBand', [transition('* => *', useAnimation(rubberBand))]),
-    trigger('shake', [transition('* => *', useAnimation(shake))]),
-    trigger('swing', [transition('* => *', useAnimation(swing))]),
-    trigger('tada', [transition('* => *', useAnimation(tada))]),
-    trigger('wobble', [transition('* => *', useAnimation(wobble))]),
-    trigger('jello', [transition('* => *', useAnimation(jello))]),
-
-    trigger('bounceIn', [transition('* => *', useAnimation(bounceIn))]),
-    trigger('bounceInDown', [transition('* => *', useAnimation(bounceInDown))]),
-    trigger('bounceInLeft', [transition('* => *', useAnimation(bounceInLeft))]),
-    trigger('bounceOut', [transition('* => *', useAnimation(bounceOut))]),
-    trigger('bounceOutRight', [
-      transition('* => *', useAnimation(bounceOutRight))
-    ]),
-    trigger('bounceOutUp', [transition('* => *', useAnimation(bounceOutUp))]),
-
-    trigger('fadeIn', [transition('* => *', useAnimation(fadeIn))]),
-    trigger('fadeInDown', [transition('* => *', useAnimation(fadeInDown))]),
-    trigger('fadeInLeft', [transition('* => *', useAnimation(fadeInLeft))]),
-    trigger('fadeOut', [transition('* => *', useAnimation(fadeOut))]),
-    trigger('fadeOutUp', [transition('* => *', useAnimation(fadeOutUp))]),
-    trigger('fadeOutRight', [transition('* => *', useAnimation(fadeOutRight))]),
-
-    trigger('slideInDown', [transition('* => *', useAnimation(slideInDown))]),
-    trigger('slideInLeft', [transition('* => *', useAnimation(slideInLeft))]),
-    trigger('slideOutUp', [transition('* => *', useAnimation(slideOutUp))]),
-    trigger('slideOutRight', [
-      transition('* => *', useAnimation(slideOutRight))
-    ]),
-
-    trigger('flip', [transition('* => *', useAnimation(flip))]),
-    trigger('flipInX', [transition('* => *', useAnimation(flipInX))]),
-    trigger('flipInY', [transition('* => *', useAnimation(flipInY))]),
-    trigger('flipOutX', [transition('* => *', useAnimation(flipOutX))]),
-    trigger('flipOutY', [transition('* => *', useAnimation(flipOutY))]),
-
-    trigger('lightSpeedIn', [transition('* => *', useAnimation(lightSpeedIn))]),
-    trigger('lightSpeedOut', [
-      transition('* => *', useAnimation(lightSpeedOut))
-    ]),
-
-    trigger('rotateIn', [transition('* => *', useAnimation(rotateIn))]),
-    trigger('rotateInDownLeft', [
-      transition('* => *', useAnimation(rotateInDownLeft))
-    ]),
-    trigger('rotateInUpRight', [
-      transition('* => *', useAnimation(rotateInUpRight))
-    ]),
-    trigger('rotateOut', [transition('* => *', useAnimation(rotateOut))]),
-    trigger('rotateOutUpLeft', [
-      transition('* => *', useAnimation(rotateOutUpLeft))
-    ]),
-    trigger('rotateOutDownRight', [
-      transition('* => *', useAnimation(rotateOutDownRight))
-    ]),
-
-    trigger('hinge', [transition('* => *', useAnimation(hinge))]),
-    trigger('jackInTheBox', [transition('* => *', useAnimation(jackInTheBox))]),
-    trigger('rollIn', [transition('* => *', useAnimation(rollIn))]),
-    trigger('rollOut', [transition('* => *', useAnimation(rollOut))]),
-
-    trigger('zoomIn', [transition('* => *', useAnimation(zoomIn))]),
-    trigger('zoomInLeft', [transition('* => *', useAnimation(zoomInLeft))]),
-    trigger('zoomInDown', [transition('* => *', useAnimation(zoomInDown))]),
-    trigger('zoomOut', [transition('* => *', useAnimation(zoomOut))]),
-    trigger('zoomOutUp', [transition('* => *', useAnimation(zoomOutUp))]),
-    trigger('zoomOutRight', [transition('* => *', useAnimation(zoomOutRight))])
-  ]
+  animations: [trigger('tada', [transition('* => *', useAnimation(tada))])],
 })
 export class AppComponent {
-  bounce = false;
-  flash = false;
-  pulse = false;
-  rubberBand = false;
-  shake = false;
-  swing = false;
-  tada = false;
-  wobble = false;
-  jello = false;
+  attentionSeekersAnimations = {
+    bounce,
+    flash,
+    pulse,
+    rubberBand,
+    shakeX,
+    shakeY,
+    headShake,
+    swing,
+    tada,
+    wobble,
+    jello,
+    heartBeat,
+  };
 
-  attentionSeekers = [
-    'bounce',
-    'flash',
-    'pulse',
-    'rubberBand',
-    'shake',
-    'swing',
-    'tada',
-    'wobble',
-    'jello'
-  ];
+  backEntrances = {
+    backInDown,
+    backInLeft,
+    backInRight,
+    backInUp,
+  };
 
-  // ==================
+  backExits = {
+    backOutDown,
+    backOutLeft,
+    backOutRight,
+    backOutUp,
+  };
 
-  bounceIn = false;
-  bounceInDown = false;
-  bounceInLeft = false;
-  bounceOut = false;
-  bounceOutUp = false;
-  bounceOutRight = false;
+  bouncingEntrances = {
+    bounceIn,
+    bounceInDown,
+    bounceInLeft,
+    bounceInRight,
+    bounceInUp,
+  };
 
-  bouncing = [
-    'bounceIn',
-    'bounceInDown',
-    'bounceInLeft',
-    'bounceOut',
-    'bounceOutUp',
-    'bounceOutRight'
-  ];
+  bouncingExits = {
+    bounceOut,
+    bounceOutDown,
+    bounceOutLeft,
+    bounceOutRight,
+    bounceOutUp,
+  };
 
-  // ==================
+  fadingEntrances = {
+    fadeIn,
+    fadeInDown,
+    fadeInDownBig,
+    fadeInLeft,
+    fadeInLeftBig,
+    fadeInRight,
+    fadeInRightBig,
+    fadeInUp,
+    fadeInUpBig,
+    fadeInTopLeft,
+    fadeInTopRight,
+    fadeInBottomLeft,
+    fadeInBottomRight,
+  };
 
-  fadeIn = false;
-  fadeInDown = false;
-  fadeInLeft = false;
-  fadeOut = false;
-  fadeOutUp = false;
-  fadeOutRight = false;
+  fadingExits = {
+    fadeOut,
+    fadeOutDown,
+    fadeOutDownBig,
+    fadeOutLeft,
+    fadeOutLeftBig,
+    fadeOutRight,
+    fadeOutRightBig,
+    fadeOutUp,
+    fadeOutUpBig,
+    fadeOutTopLeft,
+    fadeOutTopRight,
+    fadeOutBottomRight,
+    fadeOutBottomLeft,
+  };
 
-  // ==================
+  flippers = { flip, flipInX, flipInY, flipOutX, flipOutY };
 
-  fading = [
-    'fadeIn',
-    'fadeInDown',
-    'fadeInLeft',
-    'fadeOut',
-    'fadeOutUp',
-    'fadeOutRight'
-  ];
+  lightspeed = {
+    lightSpeedInRight,
+    lightSpeedInLeft,
+    lightSpeedOutRight,
+    lightSpeedOutLeft,
+  };
 
-  // ==================
+  rotatingEntrances = {
+    rotateIn,
+    rotateInDownLeft,
+    rotateInDownRight,
+    rotateInUpLeft,
+    rotateInUpRight,
+  };
 
-  slideInDown = false;
-  slideInLeft = false;
-  slideOutUp = false;
-  slideOutRight = false;
+  rotatingExits = {
+    rotateOut,
+    rotateOutDownLeft,
+    rotateOutDownRight,
+    rotateOutUpLeft,
+    rotateOutUpRight,
+  };
 
-  sliding = ['slideInDown', 'slideInLeft', 'slideOutUp', 'slideOutRight'];
+  specials = {
+    hinge,
+    jackInTheBox,
+    rollIn,
+    rollOut,
+  };
 
-  // ==================
+  zoomingEntrances = {
+    zoomIn,
+    zoomInDown,
+    zoomInLeft,
+    zoomInRight,
+    zoomInUp,
+  };
 
-  flip = false;
-  flipInX = false;
-  flipInY = false;
-  flipOutX = false;
-  flipOutY = false;
+  zoomingExits = {
+    zoomOut,
+    zoomOutDown,
+    zoomOutLeft,
+    zoomOutRight,
+    zoomOutUp,
+  };
 
-  flippers = ['flip', 'flipInX', 'flipInY', 'flipOutX', 'flipOutY'];
+  slidingEntrances = {
+    slideInDown,
+    slideInLeft,
+    slideInRight,
+    slideInUp,
+  };
 
-  // ==================
+  slidingExits = {
+    slideOutDown,
+    slideOutLeft,
+    slideOutRight,
+    slideOutUp,
+  };
 
-  lightSpeedIn = false;
-  lightSpeedOut = false;
+  // params
 
-  lightSpeed = ['lightSpeedIn', 'lightSpeedOut'];
-
-  // ==================
-
-  rotateIn = false;
-  rotateInDownLeft = false;
-  rotateInUpRight = false;
-  rotateOut = false;
-  rotateOutUpLeft = false;
-  rotateOutDownRight = false;
-
-  rotate = [
-    'rotateIn',
-    'rotateInDownLeft',
-    'rotateInUpRight',
-    'rotateOut',
-    'rotateOutUpLeft',
-    'rotateOutDownRight'
-  ];
-
-  // ==================
-
-  hinge = false;
-  jackInTheBox = false;
-  rollIn = false;
-  rollOut = false;
-
-  specials = ['hinge', 'jackInTheBox', 'rollIn', 'rollOut'];
-
-  // ==================
-
-  zoomIn = false;
-  zoomInDown = false;
-  zoomInLeft = false;
-  zoomOut = false;
-  zoomOutUp = false;
-  zoomOutRight = false;
-
-  zooming = [
-    'zoomIn',
-    'zoomInDown',
-    'zoomInLeft',
-    'zoomOut',
-    'zoomOutUp',
-    'zoomOutRight'
-  ];
-
-  animate(name: 'string') {
-    this[name] = !this[name];
-  }
+  animationTiming = 2;
+  fromOpacity = 0;
+  toOpacity = 1;
+  degrees = 90;
+  originX = 'center';
+  originY = 'center';
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,20 +1,21 @@
-import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { ExampleBoxComponent } from './example-box/example-box.component';
 
 @NgModule({
-  declarations: [
-    AppComponent
-  ],
+  declarations: [AppComponent, ExampleBoxComponent],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
+    FormsModule,
     AppRoutingModule,
-    BrowserAnimationsModule
   ],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/example-box/example-box.component.css
+++ b/src/app/example-box/example-box.component.css
@@ -1,0 +1,12 @@
+:host {
+  display: block;
+}
+
+.box {
+  background-color: #fff;
+  border-radius: 3px;
+  height: 48px;
+  width: 48px;
+  margin: 0 auto;
+  margin-top: 5rem;
+}

--- a/src/app/example-box/example-box.component.html
+++ b/src/app/example-box/example-box.component.html
@@ -1,0 +1,6 @@
+<div #box class="box"></div>
+<h3>{{ label }}</h3>
+<p>
+  <button *ngFor="let anim of animations | keyvalue" (click)="playAnim(box, anim.value)" class="btn"
+    type="button">{{ anim.key }}</button>
+</p>

--- a/src/app/example-box/example-box.component.spec.ts
+++ b/src/app/example-box/example-box.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { ExampleBoxComponent } from './example-box.component';
+
+describe('ExampleBoxComponent', () => {
+  let component: ExampleBoxComponent;
+  let fixture: ComponentFixture<ExampleBoxComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule],
+      declarations: [ExampleBoxComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExampleBoxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/example-box/example-box.component.ts
+++ b/src/app/example-box/example-box.component.ts
@@ -1,0 +1,42 @@
+import { AnimationBuilder, AnimationMetadata, AnimationPlayer } from '@angular/animations';
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-example-box',
+  templateUrl: './example-box.component.html',
+  styleUrls: ['./example-box.component.css'],
+})
+export class ExampleBoxComponent {
+  @Input() label: string;
+
+  @Input() animations: { [name: string]: AnimationMetadata } = {};
+
+  @Input() params: {
+    [name: string]: unknown;
+  } = {};
+
+  lastAnimPlayer?: AnimationPlayer;
+
+  constructor(private readonly animationBuilder: AnimationBuilder) {}
+
+  playAnim(
+    element: HTMLElement,
+    anim: AnimationMetadata | AnimationMetadata[]
+  ): void {
+    this.lastAnimPlayer?.finish();
+
+    const animPlayer = this.animationBuilder
+      .build(anim)
+      .create(element, { params: this.params });
+
+    animPlayer.init();
+    animPlayer.onDone(() => {
+      animPlayer.destroy();
+      if (animPlayer === this.lastAnimPlayer) {
+        this.lastAnimPlayer = undefined;
+      }
+    });
+    this.lastAnimPlayer = animPlayer;
+    animPlayer.play();
+  }
+}

--- a/src/app/example-box/example-box.component.ts
+++ b/src/app/example-box/example-box.component.ts
@@ -27,7 +27,7 @@ export class ExampleBoxComponent {
 
     const animPlayer = this.animationBuilder
       .build(anim)
-      .create(element, { params: this.params });
+      .create(element, { params: { ...this.params } });
 
     animPlayer.init();
     animPlayer.onDone(() => {


### PR DESCRIPTION
Add missing v4 animations (#25), also:
- also updated showcase website with all animations
- add missing fromOpacity / toOpacity params

- [x] `npm run test`
- [x] `npm run lint`

The update of the examples was made to easier handle future animations / updates in the future.
Hopefully this is okay.